### PR TITLE
+ Carp::Always

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -20,6 +20,7 @@ provides:
 recommends:
   Data::Dumper::Names: 0.03
 requires:
+  Carp::Always: 0.10
   Exception::Class: 1.14
   Test::Deep: 0.106
   Test::Differences: 0.61

--- a/lib/Test/Most.pm
+++ b/lib/Test/Most.pm
@@ -2,7 +2,7 @@ package Test::Most;
 
 use warnings;
 use strict;
-
+use Carp::Always;
 use Test::Most::Exception 'throw_failure';
 
 # XXX don't use 'base' as it can override signal handlers


### PR DESCRIPTION
CPAN test results aren't always as informative as they could be. Carp::Always would fix that!
