### PR TITLE
Fix variable name typo ($@ not @_)

### DIFF
--- a/lib/Test/Most.pm
+++ b/lib/Test/Most.pm
@@ -18,7 +18,7 @@ BEGIN {
     @Test::More::EXPORT = grep { $_ ne 'explain' } @Test::More::EXPORT;
     Test::More->import;
     eval "use Time::HiRes";
-    $HAVE_TIME_HIRES = 1 unless @_;
+    $HAVE_TIME_HIRES = 1 unless $@;
 }
 
 use Test::Builder;


### PR DESCRIPTION
Noticed this when looking at the code and assumed it was a typo
