### PR TITLE
Restore `use Test::Most import => [...]` (closes #18)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,14 @@
 Revision history for Test::Most
 
+0.42    [pending]
+
+        - Bugfix: restore support for `use Test::Most import => [...]` to
+          select which symbols to export. The 0.39 export rework caused
+          this idiom to fall through to plan(), which died with
+          "plan() doesn't understand import ARRAY(...)". `import => []`
+          falls through to the default exports, matching Test::Builder::Module
+          and pre-0.39 behaviour. (GH#18)
+
 0.41    2026-04-30
 
         - No functional changes

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,6 +21,7 @@ t/function_bail.t
 t/function_die.t
 t/import_bail.t
 t/import_die.t
+t/import_list.t
 t/import_strict_and_warnings.t
 t/lib/DuplicatePlanRegression.pm
 t/lib/OurTester.pm

--- a/lib/Test/Most.pm
+++ b/lib/Test/Most.pm
@@ -102,9 +102,31 @@ sub import {
     my %exclude_symbol;
     my $i = 0;
 
+    # Pull out `import => [...]` so it doesn't fall through to plan(), which
+    # doesn't understand it. The list drives export_to_level below.
+    #
+    # The while-with-index loop is intentional: we mutate @_ via splice as
+    # we go, and this matches the existing parser further down the sub.
+    my @explicit;
+    while ( $i < @_ ) {
+        if ( $_[$i] eq 'import' && ref $_[ $i + 1 ] eq 'ARRAY' ) {
+            @explicit = @{ ( splice @_, $i, 2 )[1] };
+            last;
+        }
+        $i++;
+    }
+    $i = 0;
+
     foreach my $do_not_import_by_default (qw/blessed reftype/) {
-        if ( grep { $_ eq $do_not_import_by_default } @_ ) {
+        if ( grep { $_ eq $do_not_import_by_default } @_, @explicit ) {
             @_ = grep { $_ ne $do_not_import_by_default } @_;
+            # If the user opted in positionally AND used import => [...],
+            # the explicit list is the export source — make sure the symbol
+            # is in it, or it would be silently dropped.
+            if ( @explicit
+                && !grep { $_ eq $do_not_import_by_default } @explicit ) {
+                push @explicit, $do_not_import_by_default;
+            }
         }
         else {
             $exclude_symbol{$do_not_import_by_default} = 1;
@@ -172,7 +194,14 @@ END
     $test->exported_to($caller);
     $test->plan(@_);
 
-    $class->export_to_level(1, $class, @EXPORT);
+    # Empty @explicit covers two cases that should both fall through to the
+    # default exports: no `import =>` was given, or `import => []` was given
+    # (which matches Test::Builder::Module / Exporter, where an empty import
+    # list means "use defaults"). When @explicit has items but `!sym`
+    # exclusions empty it out, @to_export is empty and we export nothing.
+    my @to_export
+        = @explicit ? grep { !$exclude_symbol{$_} } @explicit : @EXPORT;
+    $class->export_to_level( 1, $class, @to_export ) if @to_export;
 }
 
 sub explain {

--- a/t/import_list.t
+++ b/t/import_list.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib 'lib';
+
+# Regression test for GH#18: `use Test::Most import => [...]` died with
+# "plan() doesn't understand import ARRAY(...)" because the pair fell
+# through to plan() instead of being consumed as an export filter.
+#
+# `import => [...]` must be supplied as the first arg to actually exercise
+# the regression — it's what gets handed to plan() and what plan() chokes on.
+use Test::Most import => [qw( ok done_testing is blessed subtest )];
+
+ok 1, 'ok was imported via the explicit list';
+is 2, 2, 'is was imported via the explicit list';
+ok defined( &main::blessed ),
+    'symbols normally excluded by default may be imported when listed explicitly';
+ok !defined( &main::eq_or_diff ),
+    'symbols not in the import list are not exported';
+ok !defined( &main::dies_ok ),
+    'Test::Exception symbols not in the import list are not exported';
+ok !defined( &main::cmp_deeply ),
+    'Test::Deep symbols not in the import list are not exported';
+ok !defined( &main::warning_is ),
+    'Test::Warn symbols not in the import list are not exported';
+
+subtest 'empty import list falls through to default exports' => sub {
+    # This matches Test::Builder::Module and Exporter, both of which treat
+    # an empty import list as "use defaults". Pre-0.39 Test::Most inherited
+    # the same behaviour via `goto &Test::Builder::Module::import`, so we
+    # preserve it here.
+    package EmptyList;
+    Test::Most->import( import => [] );
+    main::ok( defined( &EmptyList::ok ),         'ok exported (default)' );
+    main::ok( defined( &EmptyList::cmp_deeply ), 'cmp_deeply exported (default)' );
+};
+
+subtest 'fully excluded import list exports nothing' => sub {
+    package AllExcluded;
+    Test::Most->import( import => [qw( is )], '!is' );
+    main::ok( !defined( &AllExcluded::is ), 'excluded symbol not exported' );
+    main::ok( !defined( &AllExcluded::ok ), 'unrelated default not exported' );
+};
+
+subtest 'import list combined with plan args' => sub {
+    package WithPlan;
+    Test::Most->import( 'no_plan', import => [qw( ok )] );
+    main::ok( defined( &WithPlan::ok ),         'ok was imported' );
+    main::ok( !defined( &WithPlan::cmp_deeply ), 'cmp_deeply not exported' );
+};
+
+subtest 'positional blessed alongside import list is honored' => sub {
+    package WithBlessed;
+    Test::Most->import( 'blessed', import => [qw( ok )] );
+    main::ok( defined( &WithBlessed::blessed ),
+        'blessed listed positionally still gets exported' );
+    main::ok( defined( &WithBlessed::ok ), 'ok from import list exported' );
+};
+
+subtest 'module exclusion still applies' => sub {
+    package WithoutDeep;
+    Test::Most->import( '-Test::Deep', import => [qw( ok )] );
+    main::ok( defined( &WithoutDeep::ok ), 'ok exported' );
+    main::ok( !defined( &WithoutDeep::cmp_deeply ),
+        'Test::Deep symbols not exported even if Test::Deep stayed loaded' );
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Closes #18.

In Test::Most ≤ 0.38 the `Test::Builder::Module` idiom worked:

```perl
use Test::Most import => [qw( done_testing )];
```

In 0.39+ it dies with `plan() doesn't understand import ARRAY(...)` because the export rework in 7d20ddb replaced the `goto &Test::Builder::Module::import` with a direct `$test->plan(@_)` call, and `Test::Most`'s own arg parser doesn't recognise `import`, so the pair falls through to `plan()`.

This PR restores the previous behaviour by extracting `import => [LIST]` from `@_` before calling `plan()` and using the list (with `!sym` exclusions applied) to drive `export_to_level`.

Two gotchas worth flagging:

- `Exporter` treats an empty trailing list as "use defaults", so `import => []` (or a list fully filtered by `!sym`) would silently re-export everything. The patch skips `export_to_level` when the resolved list is empty.
- `blessed` / `reftype` listed positionally alongside `import => [...]` need to be merged into the explicit list, otherwise they'd be stripped from `@_` but never reach `export_to_level`.

## Test plan

- [x] `t/import_list.t` (new): regression coverage for the original idiom plus subtests for the edge cases above (empty list, fully excluded list, plan + import, positional `blessed` + import, `-Test::Deep` + import).
- [x] Full existing suite still passes (18 files / 103 tests).
- [x] Manual repro from the issue now succeeds:
  ```
  $ perl -Ilib -e 'use Test::Most import => [qw( done_testing )]; done_testing;'
  1..0
  ```